### PR TITLE
DEVOPS-5514: Fix action definition for action-git-auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Wait'
-description: 'Wait a designated number of milliseconds'
+name: action-git-auth
+description: Injects git auth credentials into the host using .insteadOf rules in global .gitconfig
 inputs:
   token:
     description: GitHub personal access token


### PR DESCRIPTION

**Description**

Accidentally left default name and description in there... whoops.

Fixes [#DEVOPS-5514](https://team-turo.atlassian.net/browse/DEVOPS-5514)

**Changes**

* fix(action): update name and description

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
