### PR TITLE
fix(commitlint): no longer override rules in commitlint config

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,4 +1,2 @@
 extends:
   - "@open-turo/commitlint-config-conventional"
-rules:
-  body-max-line-length: [2, "always", 256]


### PR DESCRIPTION
Providing a longer description that should exceed 100 characters if I just keep typing away while
Jake is eating lunch I should eventually pole vault over the 100 character maximum body length
allowed by default to see if the problem still happens now