### PR TITLE
feat: upgrade to node18

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,6 @@ inputs:
 runs:
   ## Injects git auth credentials into the host using .insteadOf rules in
   ## global .gitconfig.
-  using: "node16"
+  using: "node18"
   main: "dist/main/index.js"
   post: "dist/post/index.js"


### PR DESCRIPTION
Node 16 went [end of life](https://nodejs.org/en/blog/announcements/nodejs16-eol) on Sep 11, 2023, upgrading to [active LTS](https://nodejs.dev/en/about/releases/).

* Upgrade to node 18